### PR TITLE
No already exists errors

### DIFF
--- a/src/db/managers/manager_competition.php
+++ b/src/db/managers/manager_competition.php
@@ -174,7 +174,7 @@ class managerCompetition
 
         // check if any competitions were found if so return to prevent duplicates
         if ($found_competitions != null)
-            return self::ERROR_ALREADY_EXISTING;
+            return $found_competitions[0]; // return the first found competition
 
         // update fields in competition object
 

--- a/src/db/managers/manager_competition.php
+++ b/src/db/managers/manager_competition.php
@@ -173,8 +173,14 @@ class managerCompetition
         );
 
         // check if any competitions were found if so return to prevent duplicates
-        if ($found_competitions != null)
-            return $found_competitions[0]; // return the first found competition
+        if ($found_competitions != null) {
+            // if the competition already exists check if the user has access to it, if not return error
+            if ($found_competitions[0]->{competition::KEY_USER} != $this->currentUserID)
+                return self::ERROR_WRONG_USER_ID;
+
+            // seems like the user has access, so simply return the found competition
+            return $found_competitions[0];
+        }
 
         // update fields in competition object
 

--- a/src/db/managers/manager_discipline.php
+++ b/src/db/managers/manager_discipline.php
@@ -126,7 +126,7 @@ class managerDiscipline
         adaptorDiscipline::makeRepresentativeDbReady($this->db, $discipline);
 
         // search for similar disciplines in database
-        if (adaptorDiscipline::search(
+        $found_disciplines = adaptorDiscipline::search(
             $this->db,
             null,
             $this->currentCompetitionID,
@@ -134,8 +134,10 @@ class managerDiscipline
             $discipline->{discipline::KEY_FALLBACK_NAME},
             $discipline->{discipline::KEY_TYPE},
             $discipline->{discipline::KEY_ROUND}
-        ) != null)
-            return self::ERROR_ALREADY_EXISTING;
+        );
+
+        if ($found_disciplines != null)
+            return $found_disciplines[0];
 
         // update competition id in discipline
         $discipline->updateParentId($this->currentCompetitionID);

--- a/src/db/managers/manager_result.php
+++ b/src/db/managers/manager_result.php
@@ -124,15 +124,17 @@ class managerResult
         adaptorResult::makeRepresentativeDbReady($this->db, $result);
 
         // search for similar results in the database
-        if (adaptorResult::search(
+        $found_results = adaptorResult::search(
             $this->db,
             null,
             $this->currentDisciplineID,
             null,
             $result->{result::KEY_START_NUMBER},
             $result->{result::KEY_NAME}
-        ) != null)
-            return self::ERROR_ALREADY_EXISTING;
+        );
+
+        if ($found_results != null)
+            return $found_results[0];
 
         // update discipline id in result
         $result->updateParentId($this->currentDisciplineID);


### PR DESCRIPTION
If you want to add something to the database that already exists, you no longer get an error (as long as you have access to the already existing element), but rather get the already existing element in return. Please note, that doesn't replace edit, since no fields are modified in the database.